### PR TITLE
Add Uniswap sniper bot script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
-# test-codex
+# Test Codex
+
+This repository contains simple examples.
+
+## Sniper Bot
+
+The `sniper_bot.py` script monitors new Uniswap V2 pairs using The Graph API. Any pair with a daily volume above the threshold is logged to the console.
+
+### Requirements
+
+- Python 3.8+
+- `requests` library
+
+Install dependencies:
+
+```bash
+pip install requests
+```
+
+### Usage
+
+Run the bot:
+
+```bash
+python sniper_bot.py
+```
+
+It will poll for new pairs every 30 seconds and print those with high volume.

--- a/sniper_bot.py
+++ b/sniper_bot.py
@@ -1,0 +1,55 @@
+import requests
+import time
+
+# Uniswap V2 subgraph endpoint
+UNISWAP_V2_SUBGRAPH = "https://api.thegraph.com/subgraphs/name/uniswap/uniswap-v2"
+
+# Volume threshold in USD
+VOLUME_THRESHOLD = 1_000_000  # 1M USD
+
+QUERY = """
+query ($lastId: String) {
+  pairs(first: 100, orderBy: createdAtTimestamp, orderDirection: desc, where: {id_gt: $lastId}) {
+    id
+    token0 { id symbol name }
+    token1 { id symbol name }
+    volumeUSD
+  }
+}
+"""
+
+
+def fetch_new_pairs(last_id="0"):
+    response = requests.post(
+        UNISWAP_V2_SUBGRAPH,
+        json={"query": QUERY, "variables": {"lastId": last_id}},
+        timeout=10,
+    )
+    response.raise_for_status()
+    data = response.json()
+    return data["data"]["pairs"]
+
+
+def monitor():
+    last_id = "0"
+    print("Starting monitoring loop. Press Ctrl+C to exit.")
+    while True:
+        try:
+            pairs = fetch_new_pairs(last_id)
+            for pair in pairs:
+                last_id = pair["id"]
+                volume = float(pair.get("volumeUSD", 0))
+                if volume >= VOLUME_THRESHOLD:
+                    token0 = pair["token0"]["symbol"]
+                    token1 = pair["token1"]["symbol"]
+                    print(
+                        f"High volume pair detected: {token0}/{token1} volumeUSD={volume:.2f}"
+                    )
+        except Exception as e:
+            print("Error fetching pairs:", e)
+
+        time.sleep(30)
+
+
+if __name__ == "__main__":
+    monitor()


### PR DESCRIPTION
## Summary
- add minimal `sniper_bot.py` for monitoring Uniswap V2 pairs via the Graph
- update README with usage instructions

## Testing
- `pip install requests`
- `python sniper_bot.py` *(fails: no output after short run)*


------
https://chatgpt.com/codex/tasks/task_e_6845cdd43050832a970f6e3a59a4109e